### PR TITLE
fix(account-financial-reporting): Error in ledger_lines to generate r…

### DIFF
--- a/account_financial_report_webkit_xls/report/general_ledger_xls.py
+++ b/account_financial_report_webkit_xls/report/general_ledger_xls.py
@@ -283,7 +283,7 @@ class general_ledger_xls(report_xls):
                     row_pos = self.xls_write_row(
                         ws, row_pos, row_data, c_init_cell_style)
 
-                for line in account.ledger_lines:
+                for line in _p['ledger_lines'][account.id]:
 
                     cumul_debit += line.get('debit') or 0.0
                     cumul_credit += line.get('credit') or 0.0


### PR DESCRIPTION
…eport ledger

To generate report ledger, error is showed: ledger_lines not in account, changed to object _p
because this object contain the ledger_lines
