### PR TITLE
fix(open_invoices_xls.py): white lines in open invoice report

### DIFF
--- a/account_financial_report_webkit_xls/report/open_invoices_xls.py
+++ b/account_financial_report_webkit_xls/report/open_invoices_xls.py
@@ -821,7 +821,6 @@ class open_invoices_xls(report_xls):
                 # call xls equivalent of "open_invoices_inclusion.mako.html"
                 row_pos = self.print_ledger_lines(
                     row_pos, acc, _xs, xlwt, _p, data)
-            row_pos += 1
 
 open_invoices_xls('report.account.account_report_open_invoices_xls',
                   'account.account', parser=PartnersOpenInvoicesWebkit)


### PR DESCRIPTION
report printed with white lines after the report's title
