### PR TITLE
fix(trial_balance): Calculate proper initial balance for last period …

### DIFF
--- a/account_financial_report_webkit/report/common_reports.py
+++ b/account_financial_report_webkit/report/common_reports.py
@@ -334,6 +334,11 @@ class CommonReportHeaderWebkit(common_report_header):
                     ('date_start', '>=', opening_period_br.date_stop)]
 
         periods_search = [('date_stop', '<=', start_period.date_stop)]
+        # TODO: Temporal hack for make the module works with extra special
+        # periods added at the end of the fiscal year for hold the
+        # account moves needed for close the fiscal year using module
+        # l10n_es_fiscal_year_closing
+        periods_search += [('date_start', '<', start_period.date_stop)]
         periods_search += past_limit
 
         if not include_opening:


### PR DESCRIPTION
…on fiscal year when using in co

account_fiscal_year_closing module requieres two extra special periods at the end of the year for
hold the account moves that creates for close fiscal year. That extra special periods is causing
troubles getting the probler initial balances for last period in fiscal year. This is a temporal fix
for the problem while we figure what is the best option to work with: 1) Adapt modules to
fiscal_year_clossing or 2) Stop using special periods for hold account moves on fiscal year closing
